### PR TITLE
Make Scala.js 1.x default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,33 +1,30 @@
+# Scala
 *.class
 *.log
+target/
 
-# sbt specific
+# SBT
 .cache
 .cache-main
 .history
 .lib/
-dist/*
-resolution-cache/
-streams/
-lib_managed/
-src_managed/
-project/boot/
-project/plugins/project/
-project/target/
-project/project/
-target/
+dist/
+project/target
+project/project
+metals.sbt
+.metals/
+.bloop/
+.bsp/
 
-# Scala-IDE specific
-.scala_dependencies
-.worksheet
-/bin/
-.project
-.settings
-.classpath
 # OS X
+
+.DS_Store
 
 # Sublime Text
 *.sublime-workspace
 *.sublime-project
 
-.DS_Store
+# Metals
+
+# VSCode
+*.code-workspace

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,6 @@
+version = "2.0.0-RC4"
+align = more
+maxColumn = 120
+align.openParenCallSite = true
+align.openParenDefnSite = true
+rewrite.rules = [AsciiSortImports, SortModifiers]

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.4.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.21")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.2.0")
 
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.3")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/sheetfacade.sbt
+++ b/sheetfacade.sbt
@@ -4,10 +4,10 @@ name := "Roll20 Sheet Facade"
 
 organization := "com.lkroll.roll20"
 
-version := "1.0.0"
+version := "1.0.1"
 
-scalaVersion := "2.12.4"
-crossScalaVersions := Seq("2.11.11", "2.12.4")
+scalaVersion := "2.12.11"
+crossScalaVersions := Seq("2.12.11")
 
 bintrayOrganization := Some("lkrollcom")
 

--- a/src/main/scala/com/lkroll/roll20/facade/Roll20.scala
+++ b/src/main/scala/com/lkroll/roll20/facade/Roll20.scala
@@ -20,7 +20,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- * 
+ *
  */
 
 package com.lkroll.roll20.facade
@@ -35,22 +35,26 @@ object Roll20 extends js.Object {
 
   @js.native
   trait EventInfo extends js.Object {
+
     /**
-     * The original attribute that triggered the event.
-     * It is the full name (including RowID if in a repeating section) of the attribute that originally triggered this event.
-     *
-     * Note: The entire string will have been translated into lowercase and thus might not be suitable for being fed directly into getAttrs().
-     */
+      * The original attribute that triggered the event.
+      * It is the full name (including RowID if in a repeating section) of the attribute that originally triggered this event.
+      *
+      * Note: The entire string will have been translated into lowercase and thus might not be suitable for being fed directly into getAttrs().
+      */
     val sourceAttribute: String = js.native;
+
     /**
-     * The agent that triggered the event, either player or sheetworker
-     */
+      * The agent that triggered the event, either player or sheetworker
+      */
     val sourceType: String = js.native;
   }
 
   def on(event: String, callback: js.Function1[EventInfo, Unit]): Unit = js.native;
-  def getAttrs(attributeNameArray: js.Array[String], callback: js.Function1[js.Dictionary[Any], Unit]): Unit = js.native;
-  def setAttrs(values: js.Dictionary[js.Any], options: js.Object = null, callback: js.Function0[Unit] = null): Unit = js.native;
+  def getAttrs(attributeNameArray: js.Array[String], callback: js.Function1[js.Dictionary[Any], Unit]): Unit =
+    js.native;
+  def setAttrs(values: js.Dictionary[js.Any], options: js.Object = null, callback: js.Function0[Unit] = null): Unit =
+    js.native;
   def getSectionIDs(section_name: String, callback: js.Function1[js.Array[String], Unit]): Unit = js.native;
   def generateRowID(): String = js.native;
   def removeRepeatingRow(RowID: String): Unit = js.native;


### PR DESCRIPTION
We are phasing out support for Scala.js 0.6 builds and will in the future only build for 1.x.